### PR TITLE
Add TrendView with P2P plotting

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -85,12 +85,12 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python data_loader.py <path_to_pickle>")
     else:
-try:
-    paths = load_signals(sys.argv[1])
-    names = ["mep", "ssep_upper", "ssep_lower", "surgery_meta"]
-    for name, df in zip(names, paths):
-        print(f"{name}: {df.shape}")
-except (FileNotFoundError, KeyError) as e:
-    print(f"Error: {e}", file=sys.stderr)
-    sys.exit(1)
+        try:
+            paths = load_signals(sys.argv[1])
+            names = ["mep", "ssep_upper", "ssep_lower", "surgery_meta"]
+            for name, df in zip(names, paths):
+                print(f"{name}: {df.shape}")
+        except (FileNotFoundError, KeyError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,4 +1,5 @@
 from .mep_view import MepView
 from .ssep_view import SsepView
+from .trend_view import TrendView
 
-__all__ = ["MepView", "SsepView"]
+__all__ = ["MepView", "SsepView", "TrendView"]

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -4,6 +4,8 @@ from PyQt5.QtWidgets import (
     QDockWidget, QComboBox, QSlider, QListWidget,
     QListWidgetItem
 )
+
+from .trend_view import TrendView
 from PyQt5.QtCore import Qt
 
 
@@ -20,7 +22,8 @@ class MainWindow(QMainWindow):
         self.tabs = QTabWidget()
         self.tabs.addTab(QWidget(), "MEP")
         self.tabs.addTab(QWidget(), "SSEP")
-        self.tabs.addTab(QWidget(), "Trend Analysis")
+        self.trend_tab = TrendView()
+        self.tabs.addTab(self.trend_tab, "Trend Analysis")
         self.setCentralWidget(self.tabs)
 
         # Dock widget on the left for controls

--- a/ui/trend_view.py
+++ b/ui/trend_view.py
@@ -1,0 +1,116 @@
+import pandas as pd
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QRadioButton,
+    QButtonGroup,
+    QLabel,
+)
+import pyqtgraph as pg
+
+
+def calculate_p2p(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute peak-to-peak amplitude for each timestamp/channel row."""
+    if df is None or df.empty:
+        return pd.DataFrame(columns=["timestamp", "channel", "p2p"])
+
+    result = df[["timestamp", "channel", "values"]].copy()
+    result["p2p"] = result["values"].apply(
+        lambda arr: max(arr) - min(arr) if len(arr) > 0 else 0
+    )
+    return result[["timestamp", "channel", "p2p"]]
+
+
+class TrendView(QWidget):
+    """Widget for displaying peak-to-peak trends across time."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.mep_df = None
+        self.ssep_upper_df = None
+        self.ssep_lower_df = None
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        # Radio buttons to select data source
+        radio_layout = QHBoxLayout()
+        self.mep_radio = QRadioButton("MEP")
+        self.ssep_radio = QRadioButton("SSEP")
+        self.mep_radio.setChecked(True)
+        group = QButtonGroup(self)
+        group.addButton(self.mep_radio)
+        group.addButton(self.ssep_radio)
+        self.mep_radio.toggled.connect(self.update_view)
+        self.ssep_radio.toggled.connect(self.update_view)
+        radio_layout.addWidget(self.mep_radio)
+        radio_layout.addWidget(self.ssep_radio)
+        layout.addLayout(radio_layout)
+
+        # Plot widget
+        self.plot = pg.PlotWidget()
+        self.plot.showGrid(x=True, y=True, alpha=0.3)
+        layout.addWidget(self.plot)
+
+        # Stats labels
+        stats_layout = QHBoxLayout()
+        self.min_label = QLabel("Min: N/A")
+        self.max_label = QLabel("Max: N/A")
+        self.mean_label = QLabel("Mean: N/A")
+        stats_layout.addWidget(self.min_label)
+        stats_layout.addWidget(self.max_label)
+        stats_layout.addWidget(self.mean_label)
+        layout.addLayout(stats_layout)
+
+    def refresh(self, data_dict: dict) -> None:
+        """Update internal data and refresh the display."""
+        self.mep_df = data_dict.get("mep_df")
+        self.ssep_upper_df = data_dict.get("ssep_upper_df")
+        self.ssep_lower_df = data_dict.get("ssep_lower_df")
+        self.update_view()
+
+    # -----------------------------------------------------
+    # Internal helpers
+    # -----------------------------------------------------
+    def _current_dataframe(self) -> pd.DataFrame:
+        if self.mep_radio.isChecked():
+            return self.mep_df
+        if self.ssep_radio.isChecked():
+            frames = []
+            if self.ssep_upper_df is not None:
+                frames.append(self.ssep_upper_df)
+            if self.ssep_lower_df is not None:
+                frames.append(self.ssep_lower_df)
+            if frames:
+                return pd.concat(frames, ignore_index=True)
+        return None
+
+    def update_view(self) -> None:
+        df = self._current_dataframe()
+        self.plot.clear()
+        if df is None or df.empty:
+            self.min_label.setText("Min: N/A")
+            self.max_label.setText("Max: N/A")
+            self.mean_label.setText("Mean: N/A")
+            return
+
+        p2p_df = calculate_p2p(df)
+
+        # Compute stats
+        global_min = p2p_df["p2p"].min()
+        global_max = p2p_df["p2p"].max()
+        global_mean = p2p_df["p2p"].mean()
+        self.min_label.setText(f"Min: {global_min:.2f}")
+        self.max_label.setText(f"Max: {global_max:.2f}")
+        self.mean_label.setText(f"Mean: {global_mean:.2f}")
+
+        for channel in sorted(p2p_df["channel"].unique()):
+            subset = p2p_df[p2p_df["channel"] == channel]
+            x = subset["timestamp"].to_list()
+            y = subset["p2p"].to_list()
+            self.plot.plot(x, y, pen=pg.mkPen(width=2), name=str(channel))
+


### PR DESCRIPTION
## Summary
- compute peak-to-peak values with `calculate_p2p`
- add new `TrendView` widget to view P2P trends
- expose `TrendView` from ui package
- integrate `TrendView` into main window tabs
- fix `data_loader` script indentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a97fc8120832e8ce36c6f84c04add