### PR TITLE
UI enhancements for signal viewer

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -17,6 +17,7 @@ def main() -> None:
             dialog.mep_df,
             dialog.ssep_upper_df,
             dialog.ssep_lower_df,
+            dialog.surgery_meta_df,
         )
         window.trend_tab.refresh({
             "mep_df": dialog.mep_df,

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -10,7 +10,16 @@ class SsepView(pg.PlotWidget):
         self.showGrid(x=True, y=True, alpha=0.3)
         self._legend = self.addLegend(offset=(10, 10))
 
-    def update_view(self, ssep_upper_df, ssep_lower_df, surgery_id, timestamp, channels_ordered):
+    def update_view(
+        self,
+        ssep_upper_df,
+        ssep_lower_df,
+        surgery_id,
+        timestamp,
+        channels_ordered,
+        sample_start=0,
+        sample_end=0,
+    ):
         """Update the plot with SSEP and baseline signals.
 
         Parameters
@@ -66,14 +75,21 @@ class SsepView(pg.PlotWidget):
             row = row.iloc[0]
             values = row["values"]
             baseline = row["baseline_values"]
+            rate = row.get("signal_rate", "?")
             region = row.get("region", "")
+            if sample_end and sample_end > sample_start:
+                values = values[sample_start:sample_end]
+                baseline = baseline[sample_start:sample_end]
+            else:
+                values = values[sample_start:]
+                baseline = baseline[sample_start:]
 
             x_values = list(range(len(values)))
             x_baseline = list(range(len(baseline)))
             y_offset = idx * offset_step
 
             pen_color = "b" if region == "Upper" else "g"
-            name = region if region not in legend_added else None
+            name = f"{channel} ({rate} Hz)"
 
             self.plot(x_values,
                       [v + y_offset for v in values],
@@ -83,5 +99,5 @@ class SsepView(pg.PlotWidget):
                       [v + y_offset for v in baseline],
                       pen=pg.mkPen("w"))
 
-            if name:
+            if region not in legend_added:
                 legend_added.add(region)

--- a/ui/trend_view.py
+++ b/ui/trend_view.py
@@ -55,6 +55,7 @@ class TrendView(QWidget):
         # Plot widget
         self.plot = pg.PlotWidget()
         self.plot.showGrid(x=True, y=True, alpha=0.3)
+        self.legend = self.plot.addLegend(offset=(10, 10))
         layout.addWidget(self.plot)
 
         # Stats labels
@@ -98,6 +99,8 @@ class TrendView(QWidget):
     def update_view(self) -> None:
         df = self._current_dataframe()
         self.plot.clear()
+        if self.legend is not None:
+            self.legend.clear()
         if df is None or df.empty:
             self.min_label.setText("Min: N/A")
             self.max_label.setText("Max: N/A")
@@ -123,9 +126,15 @@ class TrendView(QWidget):
         else:
             channels = sorted(unique_channels)
 
-        for channel in channels:
+        for idx, channel in enumerate(channels):
             subset = p2p_df[p2p_df["channel"] == channel]
             x = subset["timestamp"].to_list()
             y = subset["p2p"].to_list()
-            self.plot.plot(x, y, pen=pg.mkPen(width=2), name=str(channel))
+            color = pg.intColor(idx, hues=len(channels))
+            self.plot.plot(
+                x,
+                y,
+                pen=pg.mkPen(color=color, width=2),
+                name=str(channel),
+            )
 


### PR DESCRIPTION
## Summary
- display surgery metadata for selected surgery
- allow specifying sample start and end indexes
- show channel name with sampling rate in signal plots
- color-code channels in trend analysis
- pass metadata to main window

## Testing
- `python -m py_compile run_app.py ui/*.py src/*.py`
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyQt5==5.15.9)*

------
https://chatgpt.com/codex/tasks/task_e_687ac05c5430832eb1e562eab6f70aca