### PR TITLE
UI enhancements for metadata and plotting

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -17,6 +17,7 @@ def main() -> None:
             dialog.mep_df,
             dialog.ssep_upper_df,
             dialog.ssep_lower_df,
+            dialog.surgery_meta_df,
         )
         window.trend_tab.refresh({
             "mep_df": dialog.mep_df,

--- a/ui/mep_view.py
+++ b/ui/mep_view.py
@@ -7,6 +7,7 @@ class MepView(pg.PlotWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.showGrid(x=True, y=True, alpha=0.3)
+        self._legend = self.addLegend(offset=(10, 10))
 
     def update_view(self, mep_df, surgery_id, timestamp, channels_ordered):
         """Update the plot with MEP and baseline signals.
@@ -24,6 +25,8 @@ class MepView(pg.PlotWidget):
         """
         # Clear previous content
         self.clear()
+        if self._legend is not None:
+            self._legend.clear()
 
         if mep_df is None or mep_df.empty:
             return
@@ -51,6 +54,7 @@ class MepView(pg.PlotWidget):
             row = row.iloc[0]
             values = row["values"]
             baseline = row["baseline_values"]
+            rate = row.get("signal_rate", "?")
 
             x_values = list(range(len(values)))
             x_baseline = list(range(len(baseline)))
@@ -58,7 +62,8 @@ class MepView(pg.PlotWidget):
 
             self.plot(x_values,
                       [v + y_offset for v in values],
-                      pen=pg.mkPen("r"))
+                      pen=pg.mkPen("r"),
+                      name=f"{channel} ({rate}Hz)")
             self.plot(x_baseline,
                       [v + y_offset for v in baseline],
                       pen=pg.mkPen("w"))

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -57,8 +57,6 @@ class SsepView(pg.PlotWidget):
         )
         offset_step = all_max * 1.2
 
-        legend_added = set()
-
         for idx, channel in enumerate(channels_ordered):
             row = subset[subset["channel"] == channel]
             if row.empty:
@@ -67,13 +65,14 @@ class SsepView(pg.PlotWidget):
             values = row["values"]
             baseline = row["baseline_values"]
             region = row.get("region", "")
+            rate = row.get("signal_rate", "?")
 
             x_values = list(range(len(values)))
             x_baseline = list(range(len(baseline)))
             y_offset = idx * offset_step
 
             pen_color = "b" if region == "Upper" else "g"
-            name = region if region not in legend_added else None
+            name = f"{channel} ({rate}Hz)"
 
             self.plot(x_values,
                       [v + y_offset for v in values],
@@ -82,6 +81,3 @@ class SsepView(pg.PlotWidget):
             self.plot(x_baseline,
                       [v + y_offset for v in baseline],
                       pen=pg.mkPen("w"))
-
-            if name:
-                legend_added.add(region)


### PR DESCRIPTION
## Summary
- show surgery metadata near surgery selector
- add per-channel color and legend for trend analysis
- allow selecting time intervals for trend plots
- include channel name and sampling rate in MEP and SSEP legends
- pass surgery metadata from dialog to main window

## Testing
- `python -m py_compile ui/main_window.py ui/mep_view.py ui/ssep_view.py ui/trend_view.py run_app.py`


------
https://chatgpt.com/codex/tasks/task_e_687ac05c5430832eb1e562eab6f70aca