### PR TITLE
Add metadata display and improved visualization

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -17,6 +17,7 @@ def main() -> None:
             dialog.mep_df,
             dialog.ssep_upper_df,
             dialog.ssep_lower_df,
+            dialog.surgery_meta_df,
         )
         window.trend_tab.refresh({
             "mep_df": dialog.mep_df,

--- a/ui/mep_view.py
+++ b/ui/mep_view.py
@@ -52,14 +52,20 @@ class MepView(pg.PlotWidget):
             values = row["values"]
             baseline = row["baseline_values"]
 
-            x_values = list(range(len(values)))
-            x_baseline = list(range(len(baseline)))
+            x_values = [i / row["signal_rate"] for i in range(len(values))]
+            x_baseline = [i / row["baseline_signal_rate"] for i in range(len(baseline))]
             y_offset = idx * offset_step
 
-            self.plot(x_values,
-                      [v + y_offset for v in values],
-                      pen=pg.mkPen("r"))
+            self.plot(
+                x_values,
+                [v + y_offset for v in values],
+                pen=pg.mkPen("r"),
+            )
             self.plot(x_baseline,
                       [v + y_offset for v in baseline],
                       pen=pg.mkPen("w"))
+
+            text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
+            text.setPos(x_values[-1] if x_values else 0, y_offset)
+            self.addItem(text)
 

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -68,20 +68,26 @@ class SsepView(pg.PlotWidget):
             baseline = row["baseline_values"]
             region = row.get("region", "")
 
-            x_values = list(range(len(values)))
-            x_baseline = list(range(len(baseline)))
+            x_values = [i / row["signal_rate"] for i in range(len(values))]
+            x_baseline = [i / row["baseline_signal_rate"] for i in range(len(baseline))]
             y_offset = idx * offset_step
 
             pen_color = "b" if region == "Upper" else "g"
             name = region if region not in legend_added else None
 
-            self.plot(x_values,
-                      [v + y_offset for v in values],
-                      pen=pg.mkPen(pen_color),
-                      name=name)
+            self.plot(
+                x_values,
+                [v + y_offset for v in values],
+                pen=pg.mkPen(pen_color),
+                name=name,
+            )
             self.plot(x_baseline,
                       [v + y_offset for v in baseline],
                       pen=pg.mkPen("w"))
+
+            text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
+            text.setPos(x_values[-1] if x_values else 0, y_offset)
+            self.addItem(text)
 
             if name:
                 legend_added.add(region)

--- a/ui/trend_view.py
+++ b/ui/trend_view.py
@@ -55,6 +55,7 @@ class TrendView(QWidget):
         # Plot widget
         self.plot = pg.PlotWidget()
         self.plot.showGrid(x=True, y=True, alpha=0.3)
+        self._legend = self.plot.addLegend()
         layout.addWidget(self.plot)
 
         # Stats labels
@@ -98,6 +99,8 @@ class TrendView(QWidget):
     def update_view(self) -> None:
         df = self._current_dataframe()
         self.plot.clear()
+        if self._legend is not None:
+            self._legend.clear()
         if df is None or df.empty:
             self.min_label.setText("Min: N/A")
             self.max_label.setText("Max: N/A")
@@ -123,9 +126,10 @@ class TrendView(QWidget):
         else:
             channels = sorted(unique_channels)
 
-        for channel in channels:
+        for idx, channel in enumerate(channels):
             subset = p2p_df[p2p_df["channel"] == channel]
             x = subset["timestamp"].to_list()
             y = subset["p2p"].to_list()
-            self.plot.plot(x, y, pen=pg.mkPen(width=2), name=str(channel))
+            color = pg.intColor(idx, hues=len(channels))
+            self.plot.plot(x, y, pen=pg.mkPen(color, width=2), name=str(channel))
 


### PR DESCRIPTION
## Summary
- show surgery metadata when selecting a surgery
- allow setting a start and end timestamp range in the UI
- plot signal data using sample rate and show channel info
- color trend plots per channel with legend

## Testing
- `python -m py_compile run_app.py ui/*.py src/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac05c5430832eb1e562eab6f70aca