### PR TITLE
Implement dark theme and new UI components

### DIFF
--- a/resources/dark.qss
+++ b/resources/dark.qss
@@ -1,0 +1,10 @@
+/* Dark theme skeleton */
+QWidget { background: #282C34; color: #ABB2BF; }
+QToolTip { color:#282C34; background:#E5C07B; border:0; }
+QTabBar::tab { background:#3E4451; padding:6px 12px; border-radius:4px; }
+QTabBar::tab:selected { background:#61AFEF; color:#FFFFFF; }
+QDockWidget::title { background:#3E4451; text-align:center; }
+QSlider::groove:horizontal { height:4px; background:#3E4451; }
+QSlider::handle:horizontal { width:14px; background:#E06C75; margin:-5px 0; border-radius:7px; }
+QPushButton { background:#3E4451; border:1px solid #ABB2BF; padding:4px 10px; }
+QPushButton:hover { background:#E06C75; }

--- a/run_app.py
+++ b/run_app.py
@@ -1,5 +1,6 @@
 import sys
 from PyQt5.QtWidgets import QApplication, QDialog
+import style
 
 from ui.launch_dialog import LaunchDialog
 from ui.main_window import MainWindow
@@ -7,6 +8,7 @@ from ui.main_window import MainWindow
 
 def main() -> None:
     app = QApplication(sys.argv)
+    style.apply_dark_theme(app)
     dialog = LaunchDialog()
     if dialog.exec_() != QDialog.Accepted:
         sys.exit(0)

--- a/style.py
+++ b/style.py
@@ -1,0 +1,18 @@
+import os
+import pyqtgraph as pg
+
+
+def apply_dark_theme(app):
+    """Apply the bundled dark theme to the given QApplication."""
+    qss_path = os.path.join(os.path.dirname(__file__), "resources", "dark.qss")
+    try:
+        with open(qss_path, "r", encoding="utf-8") as f:
+            app.setStyleSheet(f.read())
+    except FileNotFoundError:
+        pass
+
+    pg.setConfigOptions(
+        background="#282C34",
+        foreground="#ABB2BF",
+        antialias=True,
+    )

--- a/ui/controls_dock.py
+++ b/ui/controls_dock.py
@@ -1,0 +1,72 @@
+from PyQt5.QtWidgets import (
+    QDockWidget,
+    QWidget,
+    QVBoxLayout,
+    QFormLayout,
+    QLabel,
+    QComboBox,
+    QListWidget,
+    QListWidgetItem,
+    QAbstractItemView,
+    QSlider,
+    QSpinBox,
+    QHBoxLayout,
+    QPushButton,
+)
+from PyQt5.QtCore import Qt, pyqtSignal
+
+
+class ChannelListWidget(QListWidget):
+    """List widget that emits a signal after internal drag-drop."""
+
+    dropped = pyqtSignal()
+
+    def dropEvent(self, event):
+        super().dropEvent(event)
+        self.dropped.emit()
+
+
+class ControlsDock(QDockWidget):
+    """Collapsible dock with signal controls."""
+
+    def __init__(self, parent=None):
+        super().__init__("Controls", parent)
+        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+
+        container = QWidget()
+        layout = QVBoxLayout(container)
+
+        self.surgery_combo = QComboBox()
+        layout.addWidget(self.surgery_combo)
+
+        form = QFormLayout()
+        self.date_label = QLabel("N/A")
+        self.protocol_label = QLabel("N/A")
+        form.addRow("Date:", self.date_label)
+        form.addRow("Protocol:", self.protocol_label)
+        layout.addLayout(form)
+
+        self.channel_list = ChannelListWidget()
+        self.channel_list.setDragDropMode(QAbstractItemView.InternalMove)
+        layout.addWidget(self.channel_list)
+
+        self.timestamp_slider = QSlider(Qt.Horizontal)
+        layout.addWidget(self.timestamp_slider)
+
+        interval_layout = QHBoxLayout()
+        self.start_spin = QSpinBox()
+        self.end_spin = QSpinBox()
+        interval_layout.addWidget(self.start_spin)
+        interval_layout.addWidget(self.end_spin)
+        layout.addLayout(interval_layout)
+
+        export_layout = QHBoxLayout()
+        self.export_png_btn = QPushButton("Export PNG")
+        self.export_csv_btn = QPushButton("Export CSV")
+        export_layout.addWidget(self.export_png_btn)
+        export_layout.addWidget(self.export_csv_btn)
+        layout.addLayout(export_layout)
+
+        self.setWidget(container)
+        self.setMinimumWidth(280)
+        self.setMaximumWidth(280)

--- a/ui/mep_view.py
+++ b/ui/mep_view.py
@@ -1,12 +1,12 @@
 import pyqtgraph as pg
+from .plot_widgets import BasePlotWidget, MEP_PEN, BASELINE_PEN
 
 
-class MepView(pg.PlotWidget):
+class MepView(BasePlotWidget):
     """Widget for displaying MEP signals."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.showGrid(x=True, y=True, alpha=0.3)
 
     def update_view(self, mep_df, surgery_id, timestamp, channels_ordered):
         """Update the plot with MEP and baseline signals.
@@ -59,11 +59,13 @@ class MepView(pg.PlotWidget):
             self.plot(
                 x_values,
                 [v + y_offset for v in values],
-                pen=pg.mkPen("r"),
+                pen=MEP_PEN,
             )
-            self.plot(x_baseline,
-                      [v + y_offset for v in baseline],
-                      pen=pg.mkPen("w"))
+            self.plot(
+                x_baseline,
+                [v + y_offset for v in baseline],
+                pen=BASELINE_PEN,
+            )
 
             text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
             text.setPos(x_values[-1] if x_values else 0, y_offset)

--- a/ui/plot_widgets.py
+++ b/ui/plot_widgets.py
@@ -1,0 +1,55 @@
+import csv
+import io
+from PyQt5.QtWidgets import QMenu, QFileDialog, QToolTip
+from PyQt5.QtGui import QGuiApplication, QCursor
+from PyQt5.QtCore import Qt
+import pyqtgraph as pg
+
+
+MEP_PEN = pg.mkPen("#E06C75", width=1.2)
+SSEP_U_PEN = pg.mkPen("#61AFEF", width=1.2)
+SSEP_L_PEN = pg.mkPen("#98C379", width=1.2)
+BASELINE_PEN = pg.mkPen("#ABB2BF", width=1, style=pg.QtCore.Qt.DashLine)
+
+
+class CustomPlotMenu(QMenu):
+    """Context menu with export helpers."""
+
+    def __init__(self, plot_widget):
+        super().__init__()
+        self._plot = plot_widget
+        self.addAction("Export as PNG", self.export_png)
+        self.addAction("Copy CSV of visible data", self.copy_csv)
+
+    def export_png(self):
+        path, _ = QFileDialog.getSaveFileName(self._plot, "Export Plot", "", "PNG Image (*.png)")
+        if path:
+            exporter = pg.exporters.ImageExporter(self._plot.plotItem)
+            exporter.export(path)
+
+    def copy_csv(self):
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["x", "y"])
+        for item in self._plot.listDataItems():
+            x, y = item.getData()
+            for xv, yv in zip(x, y):
+                writer.writerow([xv, yv])
+        QGuiApplication.clipboard().setText(output.getvalue())
+
+
+class BasePlotWidget(pg.PlotWidget):
+    """Common plot widget with dark theme helpers."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.showGrid(x=True, y=True, alpha=0.3)
+        self.addLegend(offset=(30, 10))
+        self.scene().contextMenu = CustomPlotMenu(self)
+        self._hover_proxy = pg.SignalProxy(self.scene().sigMouseMoved, rateLimit=60, slot=self._show_tooltip)
+
+    def _show_tooltip(self, event):
+        pos = event[0]
+        if self.sceneBoundingRect().contains(pos):
+            point = self.plotItem.vb.mapSceneToView(pos)
+            QToolTip.showText(QCursor.pos(), f"{point.x():.2f}, {point.y():.2f}")

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -1,13 +1,13 @@
 import pandas as pd
 import pyqtgraph as pg
+from .plot_widgets import BasePlotWidget, SSEP_U_PEN, SSEP_L_PEN, BASELINE_PEN
 
 
-class SsepView(pg.PlotWidget):
+class SsepView(BasePlotWidget):
     """Widget for displaying SSEP signals."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.showGrid(x=True, y=True, alpha=0.3)
         self._legend = self.addLegend(offset=(10, 10))
 
     def update_view(self, ssep_upper_df, ssep_lower_df, surgery_id, timestamp, channels_ordered):
@@ -72,18 +72,20 @@ class SsepView(pg.PlotWidget):
             x_baseline = [i / row["baseline_signal_rate"] for i in range(len(baseline))]
             y_offset = idx * offset_step
 
-            pen_color = "b" if region == "Upper" else "g"
+            pen = SSEP_U_PEN if region == "Upper" else SSEP_L_PEN
             name = region if region not in legend_added else None
 
             self.plot(
                 x_values,
                 [v + y_offset for v in values],
-                pen=pg.mkPen(pen_color),
+                pen=pen,
                 name=name,
             )
-            self.plot(x_baseline,
-                      [v + y_offset for v in baseline],
-                      pen=pg.mkPen("w"))
+            self.plot(
+                x_baseline,
+                [v + y_offset for v in baseline],
+                pen=BASELINE_PEN,
+            )
 
             text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
             text.setPos(x_values[-1] if x_values else 0, y_offset)

--- a/ui/trend_view.py
+++ b/ui/trend_view.py
@@ -6,8 +6,11 @@ from PyQt5.QtWidgets import (
     QRadioButton,
     QButtonGroup,
     QLabel,
+    QSplitter,
 )
 import pyqtgraph as pg
+from PyQt5.QtCore import Qt
+from .plot_widgets import BasePlotWidget
 
 
 def calculate_p2p(df: pd.DataFrame) -> pd.DataFrame:
@@ -52,21 +55,22 @@ class TrendView(QWidget):
         radio_layout.addWidget(self.ssep_radio)
         layout.addLayout(radio_layout)
 
-        # Plot widget
-        self.plot = pg.PlotWidget()
-        self.plot.showGrid(x=True, y=True, alpha=0.3)
+        self.splitter = QSplitter(Qt.Vertical)
+        self.plot = BasePlotWidget()
         self._legend = self.plot.addLegend()
-        layout.addWidget(self.plot)
+        self.splitter.addWidget(self.plot)
 
-        # Stats labels
-        stats_layout = QHBoxLayout()
+        stats_widget = QWidget()
+        stats_layout = QHBoxLayout(stats_widget)
         self.min_label = QLabel("Min: N/A")
         self.max_label = QLabel("Max: N/A")
         self.mean_label = QLabel("Mean: N/A")
         stats_layout.addWidget(self.min_label)
         stats_layout.addWidget(self.max_label)
         stats_layout.addWidget(self.mean_label)
-        layout.addLayout(stats_layout)
+        self.splitter.addWidget(stats_widget)
+
+        layout.addWidget(self.splitter)
 
     def refresh(self, data_dict: dict) -> None:
         """Update internal data and refresh the display."""


### PR DESCRIPTION
## Summary
- add dark stylesheet and helper to apply theme
- load dark theme in app startup
- create `ControlsDock` for sidebar controls
- add generic plot widget utilities and update signal views
- refactor `TrendView` layout with splitter and stats

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ac7c5523c832ea05a836919f52e26