### PR TITLE
Implement dark theme and UI tweaks

### DIFF
--- a/resources/dark.qss
+++ b/resources/dark.qss
@@ -1,0 +1,10 @@
+/* Dark theme skeleton */
+QWidget { background: #282C34; color: #ABB2BF; }
+QToolTip { color:#282C34; background:#E5C07B; border:0; }
+QTabBar::tab { background:#3E4451; padding:6px 12px; border-radius:4px; }
+QTabBar::tab:selected { background:#61AFEF; color:#FFFFFF; }
+QDockWidget::title { background:#3E4451; text-align:center; }
+QSlider::groove:horizontal { height:4px; background:#3E4451; }
+QSlider::handle:horizontal { width:14px; background:#E06C75; margin:-5px 0; border-radius:7px; }
+QPushButton { background:#3E4451; border:1px solid #ABB2BF; padding:4px 10px; }
+QPushButton:hover { background:#E06C75; }

--- a/style.py
+++ b/style.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import pyqtgraph as pg
+
+
+_QSS_PATH = Path(__file__).resolve().parent / "resources" / "dark.qss"
+
+
+def apply_dark_theme(app):
+    """Apply dark stylesheet and PyQtGraph theme to the given QApplication."""
+    if _QSS_PATH.exists():
+        with open(_QSS_PATH, "r") as f:
+            app.setStyleSheet(f.read())
+    pg.setConfigOptions(
+        background="#282C34",
+        foreground="#ABB2BF",
+        antialias=True,
+    )

--- a/ui/controls_dock.py
+++ b/ui/controls_dock.py
@@ -1,0 +1,89 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QFormLayout,
+    QComboBox,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QAbstractItemView,
+    QSlider,
+    QSpinBox,
+    QPushButton,
+    QHBoxLayout,
+)
+from PyQt5.QtCore import Qt, pyqtSignal
+
+
+class ChannelListWidget(QListWidget):
+    """List widget that emits a signal after internal drag-drop."""
+
+    dropped = pyqtSignal()
+
+    def dropEvent(self, event):
+        super().dropEvent(event)
+        self.dropped.emit()
+
+
+class ControlsDock(QWidget):
+    """Container widget for controls shown in the dock."""
+
+    channelsReordered = pyqtSignal(list)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        self.surgery_combo = QComboBox()
+        layout.addWidget(self.surgery_combo)
+
+        meta_form = QFormLayout()
+        self.date_label = QLabel("N/A")
+        self.protocol_label = QLabel("N/A")
+        meta_form.addRow("Date:", self.date_label)
+        meta_form.addRow("Protocol:", self.protocol_label)
+        layout.addLayout(meta_form)
+
+        self.channel_list = ChannelListWidget()
+        self.channel_list.setDragDropMode(QAbstractItemView.InternalMove)
+        layout.addWidget(self.channel_list)
+
+        self.timestamp_slider = QSlider(Qt.Horizontal)
+        layout.addWidget(self.timestamp_slider)
+
+        interval_layout = QHBoxLayout()
+        self.start_spin = QSpinBox()
+        self.end_spin = QSpinBox()
+        interval_layout.addWidget(self.start_spin)
+        interval_layout.addWidget(self.end_spin)
+        layout.addLayout(interval_layout)
+
+        btn_layout = QHBoxLayout()
+        self.export_png_btn = QPushButton("Export PNG")
+        self.export_csv_btn = QPushButton("Export CSV")
+        btn_layout.addWidget(self.export_png_btn)
+        btn_layout.addWidget(self.export_csv_btn)
+        layout.addLayout(btn_layout)
+
+        layout.addStretch()
+
+        self.channel_list.itemChanged.connect(self._emit_order)
+        self.channel_list.dropped.connect(self._emit_order)
+
+    # -----------------------------------------------------
+    # Convenience helpers
+    # -----------------------------------------------------
+    def populate_channels(self, channels, auto_check=True):
+        self.channel_list.clear()
+        for ch in channels:
+            item = QListWidgetItem(str(ch))
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Checked if auto_check else Qt.Unchecked)
+            self.channel_list.addItem(item)
+        self._emit_order()
+
+    def _emit_order(self):
+        order = [self.channel_list.item(i).text() for i in range(self.channel_list.count())]
+        self.channelsReordered.emit(order)
+

--- a/ui/mep_view.py
+++ b/ui/mep_view.py
@@ -1,12 +1,12 @@
 import pyqtgraph as pg
+from .plot_widgets import SignalPlotWidget, MEP_PEN, BASELINE_PEN
 
 
-class MepView(pg.PlotWidget):
+class MepView(SignalPlotWidget):
     """Widget for displaying MEP signals."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.showGrid(x=True, y=True, alpha=0.3)
 
     def update_view(self, mep_df, surgery_id, timestamp, channels_ordered):
         """Update the plot with MEP and baseline signals.
@@ -59,11 +59,13 @@ class MepView(pg.PlotWidget):
             self.plot(
                 x_values,
                 [v + y_offset for v in values],
-                pen=pg.mkPen("r"),
+                pen=MEP_PEN,
             )
-            self.plot(x_baseline,
-                      [v + y_offset for v in baseline],
-                      pen=pg.mkPen("w"))
+            self.plot(
+                x_baseline,
+                [v + y_offset for v in baseline],
+                pen=BASELINE_PEN,
+            )
 
             text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
             text.setPos(x_values[-1] if x_values else 0, y_offset)

--- a/ui/plot_widgets.py
+++ b/ui/plot_widgets.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import pyqtgraph as pg
+from PyQt5 import QtWidgets, QtCore, QtGui
+
+# Pens matching the dark theme
+MEP_PEN = pg.mkPen("#E06C75", width=1.2)
+SSEP_U_PEN = pg.mkPen("#61AFEF", width=1.2)
+SSEP_L_PEN = pg.mkPen("#98C379", width=1.2)
+BASELINE_PEN = pg.mkPen("#ABB2BF", width=1, style=QtCore.Qt.DashLine)
+
+
+class CustomPlotMenu(QtWidgets.QMenu):
+    """Context menu with export helpers."""
+
+    def __init__(self, widget):
+        super().__init__()
+        self._widget = widget
+        export_png = self.addAction("Export as PNG")
+        export_png.triggered.connect(self._export_png)
+        copy_csv = self.addAction("Copy CSV of visible data")
+        copy_csv.triggered.connect(self._copy_csv)
+
+    def _export_png(self):
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self._widget, "Save Image", "", "PNG Files (*.png)"
+        )
+        if path:
+            exporter = pg.exporters.ImageExporter(self._widget.plotItem)
+            exporter.export(path)
+
+    def _copy_csv(self):
+        curves = self._widget.listDataItems()
+        if not curves:
+            return
+        data = {}
+        for c in curves:
+            x, y = c.getData()
+            data.setdefault("x", x)
+            data[c.name() or "y"] = y
+        df = pd.DataFrame(data)
+        QtWidgets.QApplication.clipboard().setText(df.to_csv(index=False))
+
+
+class SignalPlotWidget(pg.PlotWidget):
+    """Base plot widget with legend and hover tooltips."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.addLegend(offset=(30, 10))
+        self._hover_proxy = pg.SignalProxy(
+            self.scene().sigMouseMoved, rateLimit=30, slot=self._show_tooltip
+        )
+        self.scene().contextMenu = CustomPlotMenu(self)
+        self.showGrid(x=True, y=True, alpha=0.3)
+
+    def _show_tooltip(self, event):
+        pos = event[0]
+        if self.plotItem.sceneBoundingRect().contains(pos):
+            point = self.plotItem.vb.mapSceneToView(pos)
+            QtWidgets.QToolTip.showText(
+                QtGui.QCursor.pos(), f"x={point.x():.2f}\ny={point.y():.2f}"
+            )
+
+

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -1,13 +1,13 @@
 import pandas as pd
 import pyqtgraph as pg
+from .plot_widgets import SignalPlotWidget, SSEP_U_PEN, SSEP_L_PEN, BASELINE_PEN
 
 
-class SsepView(pg.PlotWidget):
+class SsepView(SignalPlotWidget):
     """Widget for displaying SSEP signals."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.showGrid(x=True, y=True, alpha=0.3)
         self._legend = self.addLegend(offset=(10, 10))
 
     def update_view(self, ssep_upper_df, ssep_lower_df, surgery_id, timestamp, channels_ordered):
@@ -72,18 +72,20 @@ class SsepView(pg.PlotWidget):
             x_baseline = [i / row["baseline_signal_rate"] for i in range(len(baseline))]
             y_offset = idx * offset_step
 
-            pen_color = "b" if region == "Upper" else "g"
+            pen = SSEP_U_PEN if region == "Upper" else SSEP_L_PEN
             name = region if region not in legend_added else None
 
             self.plot(
                 x_values,
                 [v + y_offset for v in values],
-                pen=pg.mkPen(pen_color),
+                pen=pen,
                 name=name,
             )
-            self.plot(x_baseline,
-                      [v + y_offset for v in baseline],
-                      pen=pg.mkPen("w"))
+            self.plot(
+                x_baseline,
+                [v + y_offset for v in baseline],
+                pen=BASELINE_PEN,
+            )
 
             text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
             text.setPos(x_values[-1] if x_values else 0, y_offset)


### PR DESCRIPTION
## Summary
- add dark theme QSS and apply via helper
- refactor controls dock into its own module
- update plot widgets with themed pens, legends, and context menu
- apply dark style and redesigned dock in main window
- theme trend view and use splitter-based layout

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ac7c5523c832ea05a836919f52e26