### PR TITLE
Improve SSEP plotting

### DIFF
--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -64,9 +64,9 @@ class SsepView(BasePlotWidget):
 
         legend_added = set()
 
-        # Ensure upper channels are plotted above lower channels
+        # Plot lower channels first so upper channels appear above them
         ordered = []
-        for region in ("Upper", "Lower"):
+        for region in ("Lower", "Upper"):
             for ch in channels_ordered:
                 row = subset[(subset["channel"] == ch) & (subset["region"] == region)]
                 if not row.empty:

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -64,17 +64,22 @@ class SsepView(BasePlotWidget):
 
         legend_added = set()
 
-        for idx, channel in enumerate(channels_ordered):
-            row = subset[subset["channel"] == channel]
-            if row.empty:
-                continue
-            row = row.iloc[0]
+        # Ensure upper channels are plotted above lower channels
+        ordered = []
+        for region in ("Upper", "Lower"):
+            for ch in channels_ordered:
+                row = subset[(subset["channel"] == ch) & (subset["region"] == region)]
+                if not row.empty:
+                    ordered.append((region, ch, row.iloc[0]))
+
+        for idx, (region, channel, row) in enumerate(ordered):
             values = row["values"]
             baseline = row["baseline_values"]
             region = row.get("region", "")
 
-            x_values = [i / row["signal_rate"] for i in range(len(values))]
-            x_baseline = [i / row["baseline_signal_rate"] for i in range(len(baseline))]
+            # Use sample indices on the x-axis so different lengths are visible
+            x_values = list(range(len(values)))
+            x_baseline = list(range(len(baseline)))
             y_offset = idx * offset_step
 
             pen = SSEP_U_PEN if region == "Upper" else SSEP_L_PEN
@@ -92,7 +97,8 @@ class SsepView(BasePlotWidget):
                 pen=BASELINE_PEN,
             )
 
-            text = pg.TextItem(f"{channel} ({row['signal_rate']}Hz)")
+            label = f"{region}: {channel}"
+            text = pg.TextItem(f"{label} ({row['signal_rate']}Hz)")
             text.setPos(x_values[-1] if x_values else 0, y_offset)
             self.addItem(text)
 


### PR DESCRIPTION
## Summary
- ensure upper SSEP traces are drawn before lower traces
- show region in SSEP trace labels
- use sample index for SSEP plots so different signal lengths are clear

## Testing
- `python -m py_compile ui/ssep_view.py ui/main_window.py ui/mep_view.py ui/plot_widgets.py src/data_loader.py style.py ui/controls_dock.py ui/launch_dialog.py run_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687bcf688d38832e83e9710e80a7feee