### PR TITLE
Add playback controls and left/right plot separation

### DIFF
--- a/ui/controls_dock.py
+++ b/ui/controls_dock.py
@@ -72,6 +72,26 @@ class ControlsDock(QDockWidget):
         goto_layout.addWidget(self.goto_button)
         layout.addLayout(goto_layout)
 
+        # Playback controls
+        play_layout = QHBoxLayout()
+        self.play_button = QPushButton("Play")
+        self.pause_button = QPushButton("Pause")
+        self.speed_combo = QComboBox()
+        self.speed_combo.addItems([
+            "x0.5",
+            "x0.75",
+            "x1",
+            "x1.5",
+            "x1.75",
+            "x2",
+            "x5",
+        ])
+        self.speed_combo.setCurrentText("x1")
+        play_layout.addWidget(self.play_button)
+        play_layout.addWidget(self.pause_button)
+        play_layout.addWidget(self.speed_combo)
+        layout.addLayout(play_layout)
+
         # Export buttons
         export_layout = QHBoxLayout()
         self.export_png_btn = QPushButton("Export PNG")

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -1,40 +1,29 @@
 import pandas as pd
 import pyqtgraph as pg
-from .plot_widgets import (
-    BasePlotWidget,
-    SSEP_U_PEN,
-    SSEP_L_PEN,
-    BASELINE_PEN,
-)
+from PyQt5.QtWidgets import QWidget, QHBoxLayout
+
+from .plot_widgets import BasePlotWidget, SSEP_U_PEN, SSEP_L_PEN, BASELINE_PEN
 
 
-class SsepView(BasePlotWidget):
-    """Widget for displaying SSEP signals."""
+class SsepView(QWidget):
+    """Widget for displaying SSEP signals with left/right separation."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._legend = self.addLegend(offset=(10, 10))
+        layout = QHBoxLayout(self)
+        self.left_plot = BasePlotWidget()
+        self.right_plot = BasePlotWidget()
+        layout.addWidget(self.left_plot)
+        layout.addWidget(self.right_plot)
+        self.left_legend = self.left_plot.addLegend(offset=(10, 10))
+        self.right_legend = self.right_plot.addLegend(offset=(10, 10))
 
     def update_view(self, ssep_upper_df, ssep_lower_df, surgery_id, timestamp, channels_ordered):
-        """Update the plot with SSEP and baseline signals.
-
-        Parameters
-        ----------
-        ssep_upper_df : pandas.DataFrame
-            DataFrame containing upper extremity SSEP data.
-        ssep_lower_df : pandas.DataFrame
-            DataFrame containing lower extremity SSEP data.
-        surgery_id : any
-            Selected surgery id.
-        timestamp : any
-            Timestamp to display.
-        channels_ordered : list
-            Channels in the order they should be stacked.
-        """
-        # Clear previous content and legend entries
-        self.clear()
-        if self._legend is not None:
-            self._legend.clear()
+        """Update the plots with SSEP and baseline signals."""
+        for plt, legend in ((self.left_plot, self.left_legend), (self.right_plot, self.right_legend)):
+            plt.clear()
+            if legend is not None:
+                legend.clear()
 
         frames = []
         if ssep_upper_df is not None and not ssep_upper_df.empty:
@@ -46,61 +35,61 @@ class SsepView(BasePlotWidget):
 
         ssep_df = pd.concat(frames, ignore_index=True)
 
-        subset = ssep_df[(ssep_df["surgery_id"] == surgery_id) &
-                         (ssep_df["timestamp"] == timestamp) &
-                         (ssep_df["channel"].isin(channels_ordered))]
+        subset = ssep_df[
+            (ssep_df["surgery_id"] == surgery_id)
+            & (ssep_df["timestamp"] == timestamp)
+            & (ssep_df["channel"].isin(channels_ordered))
+        ]
         if subset.empty:
             return
 
         def max_abs(seq):
             return max((abs(x) for x in seq), default=0)
 
-        # Determine offset so traces don't overlap
         all_max = max(
             max((max_abs(v) for v in subset["values"]), default=1),
             max((max_abs(b) for b in subset["baseline_values"]), default=1),
         )
         offset_step = all_max * 1.2
 
-        legend_added = set()
+        left_channels = []
+        right_channels = []
+        for ch in channels_ordered:
+            if str(ch).lower().startswith("r"):
+                right_channels.append(ch)
+            else:
+                left_channels.append(ch)
 
-        # Plot lower channels first so upper channels appear above them
-        ordered = []
-        for region in ("Lower", "Upper"):
-            for ch in channels_ordered:
-                row = subset[(subset["channel"] == ch) & (subset["region"] == region)]
-                if not row.empty:
-                    ordered.append((region, ch, row.iloc[0]))
+        legend_added_left = set()
+        legend_added_right = set()
 
-        for idx, (region, channel, row) in enumerate(ordered):
-            values = row["values"]
-            baseline = row["baseline_values"]
-            region = row.get("region", "")
+        def plot_group(channels, plot, legend_added):
+            for idx, channel in enumerate(channels):
+                row = subset[subset["channel"] == channel]
+                if row.empty:
+                    continue
+                row = row.iloc[0]
+                region = row.get("region", "")
+                values = row["values"]
+                baseline = row["baseline_values"]
 
-            # Use sample indices on the x-axis so different lengths are visible
-            x_values = list(range(len(values)))
-            x_baseline = list(range(len(baseline)))
-            y_offset = idx * offset_step
+                x_values = list(range(len(values)))
+                x_baseline = list(range(len(baseline)))
+                y_offset = idx * offset_step
 
-            pen = SSEP_U_PEN if region == "Upper" else SSEP_L_PEN
-            name = region if region not in legend_added else None
+                pen = SSEP_U_PEN if region == "Upper" else SSEP_L_PEN
+                name = region if region not in legend_added else None
 
-            self.plot(
-                x_values,
-                [v + y_offset for v in values],
-                pen=pen,
-                name=name,
-            )
-            self.plot(
-                x_baseline,
-                [v + y_offset for v in baseline],
-                pen=BASELINE_PEN,
-            )
+                plot.plot(x_values, [v + y_offset for v in values], pen=pen, name=name)
+                plot.plot(x_baseline, [v + y_offset for v in baseline], pen=BASELINE_PEN)
 
-            label = f"{region}: {channel}"
-            text = pg.TextItem(f"{label} ({row['signal_rate']}Hz)")
-            text.setPos(x_values[-1] if x_values else 0, y_offset)
-            self.addItem(text)
+                label = f"{region}: {channel}"
+                text = pg.TextItem(f"{label} ({row['signal_rate']}Hz)")
+                text.setPos(x_values[-1] if x_values else 0, y_offset)
+                plot.addItem(text)
 
-            if name:
-                legend_added.add(region)
+                if name:
+                    legend_added.add(region)
+
+        plot_group(left_channels, self.left_plot, legend_added_left)
+        plot_group(right_channels, self.right_plot, legend_added_right)

--- a/ui/ssep_view.py
+++ b/ui/ssep_view.py
@@ -52,24 +52,23 @@ class SsepView(QWidget):
         )
         offset_step = all_max * 1.2
 
-        left_channels = []
-        right_channels = []
-        for ch in channels_ordered:
-            if str(ch).lower().startswith("r"):
-                right_channels.append(ch)
-            else:
-                left_channels.append(ch)
+        # Split rows into left and right groups while preserving channel order
+        left_rows = []
+        right_rows = []
+        for region in ("Lower", "Upper"):
+            for ch in channels_ordered:
+                rows = subset[(subset["channel"] == ch) & (subset["region"] == region)]
+                for _, row in rows.iterrows():
+                    target = right_rows if str(ch).lower().startswith("r") else left_rows
+                    target.append(row)
 
         legend_added_left = set()
         legend_added_right = set()
 
-        def plot_group(channels, plot, legend_added):
-            for idx, channel in enumerate(channels):
-                row = subset[subset["channel"] == channel]
-                if row.empty:
-                    continue
-                row = row.iloc[0]
+        def plot_group(rows, plot, legend_added):
+            for idx, row in enumerate(rows):
                 region = row.get("region", "")
+                channel = row["channel"]
                 values = row["values"]
                 baseline = row["baseline_values"]
 
@@ -91,5 +90,5 @@ class SsepView(QWidget):
                 if name:
                     legend_added.add(region)
 
-        plot_group(left_channels, self.left_plot, legend_added_left)
-        plot_group(right_channels, self.right_plot, legend_added_right)
+        plot_group(left_rows, self.left_plot, legend_added_left)
+        plot_group(right_rows, self.right_plot, legend_added_right)


### PR DESCRIPTION
## Summary
- display left and right channels in separate columns for MEP and SSEP views
- add play/pause controls with adjustable speed
- stop playback when data changes

## Testing
- `python -m py_compile ui/controls_dock.py ui/main_window.py ui/mep_view.py ui/ssep_view.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8cb2288832ebb025acf9108e3f1