### PR TITLE
Add playback controls and left/right plot separation

### DIFF
--- a/ui/controls_dock.py
+++ b/ui/controls_dock.py
@@ -72,6 +72,26 @@ class ControlsDock(QDockWidget):
         goto_layout.addWidget(self.goto_button)
         layout.addLayout(goto_layout)
 
+        # Playback controls
+        play_layout = QHBoxLayout()
+        self.play_button = QPushButton("Play")
+        self.pause_button = QPushButton("Pause")
+        self.speed_combo = QComboBox()
+        self.speed_combo.addItems([
+            "x0.5",
+            "x0.75",
+            "x1",
+            "x1.5",
+            "x1.75",
+            "x2",
+            "x5",
+        ])
+        self.speed_combo.setCurrentText("x1")
+        play_layout.addWidget(self.play_button)
+        play_layout.addWidget(self.pause_button)
+        play_layout.addWidget(self.speed_combo)
+        layout.addLayout(play_layout)
+
         # Export buttons
         export_layout = QHBoxLayout()
         self.export_png_btn = QPushButton("Export PNG")


### PR DESCRIPTION
## Summary
- display left and right channels in separate columns for MEP and SSEP views
- add play/pause controls with adjustable speed
- stop playback when data changes
- ensure SSEP lower and upper traces display on the correct side

## Testing
- `python -m py_compile ui/controls_dock.py ui/main_window.py ui/mep_view.py ui/ssep_view.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bd8cb2288832ebb025acf9108e3f1