### PR TITLE
Add tests and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt pytest pytest-qt ruff
+      - name: Lint
+        run: ruff check .
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ pip install pyinstaller
 python make_exe.py
 dist/NervioViz/NervioViz.exe
 ```
+
+## Development
+
+### Tests
+```bash
+pytest
+```
+
+CI
+
+GitHub Actions badge shows lint + test status on every push.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Ensure Qt runs headless during tests
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+@pytest.fixture
+def tiny_pickle(tmp_path: Path) -> str:
+    """Create a tiny pickle with minimal valid data and return its path."""
+    n = 5
+
+    def make_df(prefix: str) -> pd.DataFrame:
+        data = {
+            "surgery_id": ["S1"] * n,
+            "timestamp": list(range(n)),
+            "channel": [f"{prefix}{i}" for i in range(n)],
+            "values": [list(np.sin(np.linspace(0, np.pi, 5))) for _ in range(n)],
+            "stimulus": [{}] * n,
+            "signal_rate": [1000] * n,
+            "baseline_timestamp": [0] * n,
+            "baseline_values": [list(np.zeros(5)) for _ in range(n)],
+            "baseline_stimulus": [{}] * n,
+            "baseline_signal_rate": [1000] * n,
+        }
+        return pd.DataFrame(data)
+
+    mep_df = make_df("M")
+    ssep_upper_df = make_df("U")
+    ssep_lower_df = make_df("L")
+    surgery_meta = {"S1": {"date": "2021-01-01", "protocol": "test"}}
+
+    data = {
+        "mep_data": mep_df,
+        "ssep_upper_data": ssep_upper_df,
+        "ssep_lower_data": ssep_lower_df,
+        "surgerydata": surgery_meta,
+    }
+
+    pkl_path = tmp_path / "tiny.pkl"
+    pd.to_pickle(data, pkl_path)
+    return str(pkl_path)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,18 @@
+from PyQt5.QtWidgets import QFileDialog
+from ui.launch_dialog import LaunchDialog
+from ui.main_window import MainWindow
+
+
+def test_gui_smoke(qtbot, tiny_pickle, monkeypatch):
+    dialog = LaunchDialog()
+    qtbot.addWidget(dialog)
+
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: (tiny_pickle, ""))
+    dialog.select_file()
+
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.load_data(dialog.mep_df, dialog.ssep_upper_df, dialog.ssep_lower_df, dialog.surgery_meta_df)
+    window.show()
+    qtbot.wait(100)
+    assert window.isVisible()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from src import data_loader
+
+REQUIRED = {"surgery_id", "channel", "timestamp", "values", "baseline_values", "signal_rate"}
+
+
+def test_load_signals(tiny_pickle):
+    mep, ssep_u, ssep_l, meta = data_loader.load_signals(tiny_pickle)
+
+    for df in (mep, ssep_u, ssep_l, meta):
+        assert isinstance(df, pd.DataFrame)
+
+    for df in (mep, ssep_u, ssep_l):
+        assert REQUIRED.issubset(df.columns)

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,0 +1,20 @@
+import pytest
+import numpy as np
+import pandas as pd
+from ui.trend_view import calculate_p2p
+
+
+def test_calculate_p2p_sine():
+    amp = 2.0
+    rows = []
+    steps = 10
+    for i in range(steps):
+        a = amp * i / (steps - 1)
+        values = np.sin(np.linspace(0, 2 * np.pi, 50)) * a
+        rows.append({"timestamp": i, "channel": "ch", "values": values})
+    df = pd.DataFrame(rows)
+    out = calculate_p2p(df)
+
+    assert out["p2p"].max() == pytest.approx(amp * 2, rel=1e-2)
+    assert out["p2p"].min() == pytest.approx(0, abs=1e-8)
+    assert out["p2p"].mean() == pytest.approx(amp, rel=1e-2)

--- a/ui/controls_dock.py
+++ b/ui/controls_dock.py
@@ -7,7 +7,6 @@ from PyQt5.QtWidgets import (
     QLabel,
     QComboBox,
     QListWidget,
-    QListWidgetItem,
     QAbstractItemView,
     QSlider,
     QLineEdit,

--- a/ui/launch_dialog.py
+++ b/ui/launch_dialog.py
@@ -1,4 +1,3 @@
-import sys
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QPushButton, QLabel, QFileDialog
 )

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -3,8 +3,6 @@ import pandas as pd
 from PyQt5.QtWidgets import (
     QMainWindow,
     QTabWidget,
-    QWidget,
-    QVBoxLayout,
     QApplication,
 )
 

--- a/ui/trend_view.py
+++ b/ui/trend_view.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QLabel,
 )
 import pyqtgraph as pg
-from .plot_widgets import BasePlotWidget, MEP_PEN, SSEP_U_PEN, SSEP_L_PEN
+from .plot_widgets import BasePlotWidget
 
 
 def calculate_p2p(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- add unit tests for loader, trend calculation, and GUI
- setup pytest package configuration
- add GitHub Actions workflow for linting and testing
- document how to run tests
- clean up unused imports to satisfy ruff

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687c01fd373c832eb9bb1bf980dd24a4