### PR TITLE
Fix pandas packaging in PyInstaller build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ dist/NervioViz/NervioViz.exe
 The build script collects all required pandas and numpy binaries to avoid
 ``ImportError: DLL load failed`` errors when launching the packaged
 application.
+Existing ``dist/NervioViz`` contents are removed automatically so repeated
+builds do not require manual cleanup.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ pip install pyinstaller
 python make_exe.py
 dist/NervioViz/NervioViz.exe
 ```
-The build script collects all required pandas and numpy binaries and adds a
-runtime hook that appends ``numpy``'s bundled libraries to ``PATH``. This
-prevents ``ImportError: DLL load failed`` when launching the packaged
+The build script collects all required pandas and numpy binaries and
+uses a runtime hook that appends their ``*.libs`` directories to ``PATH``.
+This ensures that libraries bundled with these packages can be located,
+preventing ``ImportError: DLL load failed`` when launching the packaged
 application.
 Existing ``dist/NervioViz`` contents are removed automatically so repeated
 builds do not require manual cleanup.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ pip install pyinstaller
 python make_exe.py
 dist/NervioViz/NervioViz.exe
 ```
-The build script collects all required pandas and numpy binaries to avoid
-``ImportError: DLL load failed`` errors when launching the packaged
+The build script collects all required pandas and numpy binaries and adds a
+runtime hook that appends ``numpy``'s bundled libraries to ``PATH``. This
+prevents ``ImportError: DLL load failed`` when launching the packaged
 application.
 Existing ``dist/NervioViz`` contents are removed automatically so repeated
 builds do not require manual cleanup.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ pip install pyinstaller
 python make_exe.py
 dist/NervioViz/NervioViz.exe
 ```
+The build script collects all required pandas and numpy binaries to avoid
+``ImportError: DLL load failed`` errors when launching the packaged
+application.
 
 ## Development
 

--- a/make_exe.py
+++ b/make_exe.py
@@ -10,6 +10,10 @@ CMD = [
     "--exclude-module",
     "tests",
     "--noconsole",
+    "--collect-all",
+    "pandas",
+    "--collect-all",
+    "numpy",
 ]
 
 

--- a/make_exe.py
+++ b/make_exe.py
@@ -16,6 +16,8 @@ CMD = [
     "pandas",
     "--collect-all",
     "numpy",
+    "--runtime-hook",
+    "packaging/runtime_hook.py",
 ]
 
 

--- a/make_exe.py
+++ b/make_exe.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+import shutil
 
 CMD = [
     "pyinstaller",
@@ -10,6 +11,7 @@ CMD = [
     "--exclude-module",
     "tests",
     "--noconsole",
+    "--noconfirm",
     "--collect-all",
     "pandas",
     "--collect-all",
@@ -18,8 +20,12 @@ CMD = [
 
 
 def main() -> None:
-    subprocess.run(CMD, check=True)
     dist = Path("dist") / "NervioViz"
+    if dist.exists():
+        shutil.rmtree(dist)
+
+    subprocess.run(CMD, check=True)
+
     if not dist.is_dir():
         raise SystemExit("Expected dist/NervioViz not found")
     print(f"Executable created in {dist}")

--- a/make_exe.py
+++ b/make_exe.py
@@ -6,31 +6,34 @@ CMD = [
     "pyinstaller",
     "run_app.py",
     "--onedir",
-    "--name",
-    "NervioViz",
-    "--exclude-module",
-    "tests",
+    "--name", "NervioViz",
     "--noconsole",
     "--noconfirm",
-    "--collect-all",
-    "pandas",
-    "--collect-all",
-    "numpy",
-    "--runtime-hook",
-    "packaging/runtime_hook.py",
+    "--clean",
+    "--exclude-module", "tests",
+    "--exclude-module", "pyqtgraph.examples",  # <-- avoids crashing hook
+    "--collect-all", "pandas",
+    "--collect-all", "numpy",
+    "--copy-metadata", "pandas",
+    "--copy-metadata", "numpy",
+    "--runtime-hook", "packaging/runtime_hook.py",  # if needed by your app
 ]
 
 
 def main() -> None:
     dist = Path("dist") / "NervioViz"
+    build = Path("build")
+
     if dist.exists():
         shutil.rmtree(dist)
+    if build.exists():
+        shutil.rmtree(build)
 
     subprocess.run(CMD, check=True)
 
     if not dist.is_dir():
-        raise SystemExit("Expected dist/NervioViz not found")
-    print(f"Executable created in {dist}")
+        raise SystemExit("❌ Build failed: dist/NervioViz not found")
+    print(f"✅ Executable created in: {dist}")
 
 
 if __name__ == "__main__":

--- a/packaging/runtime_hook.py
+++ b/packaging/runtime_hook.py
@@ -1,0 +1,9 @@
+import os
+import numpy as _np
+
+_libdir = os.path.join(os.path.dirname(_np.__file__), 'numpy.libs')
+if os.path.isdir(_libdir):
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(_libdir)
+    else:
+        os.environ['PATH'] = _libdir + os.pathsep + os.environ.get('PATH', '')

--- a/packaging/runtime_hook.py
+++ b/packaging/runtime_hook.py
@@ -1,9 +1,25 @@
-import os
-import numpy as _np
+"""Add bundled binary directories to ``PATH`` at runtime."""
 
-_libdir = os.path.join(os.path.dirname(_np.__file__), 'numpy.libs')
-if os.path.isdir(_libdir):
-    if hasattr(os, 'add_dll_directory'):
-        os.add_dll_directory(_libdir)
-    else:
-        os.environ['PATH'] = _libdir + os.pathsep + os.environ.get('PATH', '')
+import importlib
+import os
+
+
+def _add_lib_dirs(package: str) -> None:
+    """Add ``package.libs`` or ``.libs`` subdirs to ``PATH`` if present."""
+
+    mod = importlib.import_module(package)
+    base = os.path.dirname(mod.__file__)
+    for name in (f"{package}.libs", ".libs"):
+        libdir = os.path.join(base, name)
+        if os.path.isdir(libdir):
+            if hasattr(os, "add_dll_directory"):
+                os.add_dll_directory(libdir)
+            else:  # pragma: no cover - Python < 3.8
+                os.environ["PATH"] = libdir + os.pathsep + os.environ.get("PATH", "")
+
+
+for pkg in ("numpy", "pandas"):
+    try:
+        _add_lib_dirs(pkg)
+    except Exception:  # pragma: no cover - the package might not be present
+        pass

--- a/tests/test_build_exe.py
+++ b/tests/test_build_exe.py
@@ -1,0 +1,34 @@
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.slow
+def test_build_and_run(tmp_path):
+    if shutil.which('pyinstaller') is None:
+        pytest.skip('pyinstaller not available')
+
+    env = os.environ.copy()
+    env.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+    # build executable
+    subprocess.run([sys.executable, 'make_exe.py'], check=True, env=env)
+
+    exe = Path('dist') / 'NervioViz' / ('NervioViz.exe' if os.name == 'nt' else 'NervioViz')
+    assert exe.is_file()
+
+    # run the executable briefly to ensure it starts without crashing
+    proc = subprocess.Popen([str(exe)], env=env)
+    time.sleep(2)
+    running = proc.poll() is None
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    assert running, f'process exited early with code {proc.returncode}'


### PR DESCRIPTION
## Summary
- include pandas and numpy binaries when building the executable
- document the fix in README
- add an integration test to build and briefly run the exe

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687c83323824832eb2970dbaedbbf0ca