### PR TITLE
Ensure dark theme loads in packaged app

### DIFF
--- a/make_exe.py
+++ b/make_exe.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 import shutil
+import os
 
 CMD = [
     "pyinstaller",
@@ -17,6 +18,8 @@ CMD = [
     "--copy-metadata", "pandas",
     "--copy-metadata", "numpy",
     "--runtime-hook", "packaging/runtime_hook.py",  # if needed by your app
+    "--add-data",
+    f"resources{os.pathsep}resources",
 ]
 
 

--- a/style.py
+++ b/style.py
@@ -1,11 +1,14 @@
 import os
+import sys
 from PyQt5.QtWidgets import QApplication
 import pyqtgraph as pg
 
 
 def apply_dark_theme(app: QApplication) -> None:
     """Load dark stylesheet and configure pyqtgraph colors."""
-    qss_path = os.path.join(os.path.dirname(__file__), "resources", "dark.qss")
+    # When bundled with PyInstaller, resources are extracted to ``sys._MEIPASS``.
+    base_dir = getattr(sys, "_MEIPASS", os.path.dirname(__file__))
+    qss_path = os.path.join(base_dir, "resources", "dark.qss")
     try:
         with open(qss_path, "r", encoding="utf-8") as f:
             app.setStyleSheet(f.read())


### PR DESCRIPTION
## Summary
- reference `_MEIPASS` when loading the `dark.qss` stylesheet so PyInstaller builds find the resources directory
- include the `resources` folder in PyInstaller build command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687c9976b964832e86653c80ec1784f4