### PR TITLE
Add channel subplots and stats tab

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -19,11 +19,13 @@ def main() -> None:
             dialog.ssep_lower_df,
             dialog.surgery_meta_df,
         )
-        window.trend_tab.refresh({
+        refresh_data = {
             "mep_df": dialog.mep_df,
             "ssep_upper_df": dialog.ssep_upper_df,
             "ssep_lower_df": dialog.ssep_lower_df,
-        })
+        }
+        window.trend_tab.refresh(refresh_data)
+        window.stats_tab.refresh(refresh_data)
     window.show()
     sys.exit(app.exec_())
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,17 @@
+import pytest
+import numpy as np
+import pandas as pd
+from ui.stats_view import calculate_stats
+
+
+def test_calculate_stats_basic():
+    rows = []
+    for i in range(5):
+        values = np.array([i, i + 1, i + 2])
+        rows.append({"timestamp": i, "channel": "ch", "values": values})
+    df = pd.DataFrame(rows)
+    out = calculate_stats(df)
+    assert list(out.columns) == ["timestamp", "channel", "mean", "median", "max"]
+    assert out["mean"].iloc[0] == pytest.approx(np.mean([0, 1, 2]))
+    assert out["median"].iloc[-1] == pytest.approx(np.median([4, 5, 6]))
+    assert out["max"].iloc[2] == 4

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,6 +1,7 @@
 from .mep_view import MepView
 from .ssep_view import SsepView
 from .trend_view import TrendView
+from .stats_view import StatsView
 from .controls_dock import ControlsDock
 
-__all__ = ["MepView", "SsepView", "TrendView", "ControlsDock"]
+__all__ = ["MepView", "SsepView", "TrendView", "StatsView", "ControlsDock"]


### PR DESCRIPTION
## Summary
- show each channel in its own subplot in Trend tab
- allow Trend tab channel filtering
- add new `Stats` tab to show mean/median/max signals
- connect channel ordering and data refresh for new tab
- provide helper `calculate_stats`
- test stats helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687de4c18934832e854ec3cf0677aad8