### PR TITLE
Add channel subplots and stats tab

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -19,11 +19,13 @@ def main() -> None:
             dialog.ssep_lower_df,
             dialog.surgery_meta_df,
         )
-        window.trend_tab.refresh({
+        data_dict = {
             "mep_df": dialog.mep_df,
             "ssep_upper_df": dialog.ssep_upper_df,
             "ssep_lower_df": dialog.ssep_lower_df,
-        })
+        }
+        window.trend_tab.refresh(data_dict)
+        window.stats_tab.refresh(data_dict)
     window.show()
     sys.exit(app.exec_())
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,6 +1,7 @@
 from .mep_view import MepView
 from .ssep_view import SsepView
 from .trend_view import TrendView
+from .stats_view import StatsView
 from .controls_dock import ControlsDock
 
-__all__ = ["MepView", "SsepView", "TrendView", "ControlsDock"]
+__all__ = ["MepView", "SsepView", "TrendView", "StatsView", "ControlsDock"]

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -10,6 +10,7 @@ from .controls_dock import ControlsDock
 from PyQt5.QtWidgets import QListWidgetItem
 
 from .trend_view import TrendView
+from .stats_view import StatsView
 from .mep_view import MepView
 from .ssep_view import SsepView
 from PyQt5.QtCore import Qt, pyqtSignal, QTimer
@@ -44,6 +45,8 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.ssep_view, "SSEP")
         self.trend_tab = TrendView()
         self.tabs.addTab(self.trend_tab, "Trend Analysis")
+        self.stats_tab = StatsView()
+        self.tabs.addTab(self.stats_tab, "Aggregate")
         self.tabs.currentChanged.connect(self._on_tab_changed)
         self.setCentralWidget(self.tabs)
 
@@ -118,6 +121,14 @@ class MainWindow(QMainWindow):
         self._update_surgery_meta_label()
         self.update_plots()
 
+        data_dict = {
+            "mep_df": mep_df,
+            "ssep_upper_df": ssep_upper_df,
+            "ssep_lower_df": ssep_lower_df,
+        }
+        self.trend_tab.refresh(data_dict)
+        self.stats_tab.refresh(data_dict)
+
     def on_surgery_changed(self, value):
         self._update_timestamp_slider()
         self._update_surgery_meta_label()
@@ -191,6 +202,8 @@ class MainWindow(QMainWindow):
         channels = [self.channel_list.item(i).text()
                     for i in range(self.channel_list.count())
                     if self.channel_list.item(i).checkState() == Qt.Checked]
+        self.trend_tab.set_selected_channels(channels)
+        self.stats_tab.set_selected_channels(channels)
         timestamp = None
         idx = self.timestamp_slider.value()
         if 0 <= idx < len(self._timestamps):

--- a/ui/stats_view.py
+++ b/ui/stats_view.py
@@ -1,0 +1,87 @@
+import pandas as pd
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QRadioButton,
+    QButtonGroup,
+)
+import pyqtgraph as pg
+from .plot_widgets import BasePlotWidget
+from .trend_view import calculate_p2p
+
+
+class StatsView(QWidget):
+    """Plot aggregated peak-to-peak statistics across time."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.mep_df = None
+        self.ssep_upper_df = None
+        self.ssep_lower_df = None
+        self._selected_channels = []
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        radio_layout = QHBoxLayout()
+        self.mep_radio = QRadioButton("MEP")
+        self.ssep_radio = QRadioButton("SSEP")
+        self.mep_radio.setChecked(True)
+        group = QButtonGroup(self)
+        group.addButton(self.mep_radio)
+        group.addButton(self.ssep_radio)
+        self.mep_radio.toggled.connect(self.update_view)
+        self.ssep_radio.toggled.connect(self.update_view)
+        radio_layout.addWidget(self.mep_radio)
+        radio_layout.addWidget(self.ssep_radio)
+        layout.addLayout(radio_layout)
+
+        self.plot = BasePlotWidget()
+        layout.addWidget(self.plot)
+
+    def refresh(self, data_dict: dict) -> None:
+        self.mep_df = data_dict.get("mep_df")
+        self.ssep_upper_df = data_dict.get("ssep_upper_df")
+        self.ssep_lower_df = data_dict.get("ssep_lower_df")
+        self.update_view()
+
+    def set_selected_channels(self, channels: list) -> None:
+        self._selected_channels = list(channels)
+        self.update_view()
+
+    def _current_dataframe(self) -> pd.DataFrame:
+        if self.mep_radio.isChecked():
+            return self.mep_df
+        if self.ssep_radio.isChecked():
+            frames = []
+            if self.ssep_upper_df is not None:
+                frames.append(self.ssep_upper_df)
+            if self.ssep_lower_df is not None:
+                frames.append(self.ssep_lower_df)
+            if frames:
+                return pd.concat(frames, ignore_index=True)
+        return None
+
+    def update_view(self) -> None:
+        df = self._current_dataframe()
+        self.plot.clear()
+        if df is None or df.empty:
+            return
+
+        if self._selected_channels:
+            df = df[df["channel"].isin(self._selected_channels)]
+        p2p_df = calculate_p2p(df)
+
+        grouped = p2p_df.groupby("timestamp")["p2p"]
+        mean = grouped.mean()
+        median = grouped.median()
+        max_ = grouped.max()
+
+        x = mean.index.to_list()
+        self.plot.plot(x, mean.to_list(), pen=pg.mkPen("#61AFEF", width=2), name="mean")
+        self.plot.plot(x, median.to_list(), pen=pg.mkPen("#98C379", width=2), name="median")
+        self.plot.plot(x, max_.to_list(), pen=pg.mkPen("#E06C75", width=2), name="max")


### PR DESCRIPTION
## Summary
- show each channel trend in its own subplot
- filter trend display by selected channels
- add a new Aggregate tab plotting mean, median and max p2p values
- refresh trend and stats data when loading or opening a file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687de4c18934832e854ec3cf0677aad8