### PR TITLE
Refactor trend view with L1 norm plots

### DIFF
--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,20 +1,20 @@
 import pytest
-import numpy as np
+import math
 import pandas as pd
-from ui.trend_view import calculate_p2p
+from ui.trend_view import calculate_l1_norm
 
 
-def test_calculate_p2p_sine():
+def test_calculate_l1_norm_sine():
     amp = 2.0
     rows = []
     steps = 10
     for i in range(steps):
         a = amp * i / (steps - 1)
-        values = np.sin(np.linspace(0, 2 * np.pi, 50)) * a
+        values = [math.sin(2 * math.pi * j / 49) * a for j in range(50)]
         rows.append({"timestamp": i, "channel": "ch", "values": values})
     df = pd.DataFrame(rows)
-    out = calculate_p2p(df)
+    out = calculate_l1_norm(df)
 
-    assert out["p2p"].max() == pytest.approx(amp * 2, rel=1e-2)
-    assert out["p2p"].min() == pytest.approx(0, abs=1e-8)
-    assert out["p2p"].mean() == pytest.approx(amp, rel=1e-2)
+    assert out["l1"].max() == pytest.approx(62.367, rel=1e-2)
+    assert out["l1"].min() == pytest.approx(0, abs=1e-8)
+    assert out["l1"].mean() == pytest.approx(31.1837, rel=1e-2)


### PR DESCRIPTION
## Summary
- compute L1 norm per channel
- redesign Trend tab to show per-channel subplots and global statistics
- update tests for new calculation function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687f93d5fd90832ebe0b22e85259858b