### PR TITLE
Add metric selection and incremental trend playback

### DIFF
--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,7 +1,7 @@
 import pytest
 import math
 import pandas as pd
-from ui.trend_view import calculate_l1_norm
+from ui.trend_view import calculate_l1_norm, calculate_p2p, calculate_rms
 
 
 def test_calculate_l1_norm_sine():
@@ -18,3 +18,33 @@ def test_calculate_l1_norm_sine():
     assert out["l1"].max() == pytest.approx(62.367, rel=1e-2)
     assert out["l1"].min() == pytest.approx(0, abs=1e-8)
     assert out["l1"].mean() == pytest.approx(31.1837, rel=1e-2)
+
+
+def test_calculate_p2p_sine():
+    amp = 2.0
+    rows = []
+    steps = 10
+    for i in range(steps):
+        a = amp * i / (steps - 1)
+        values = [math.sin(2 * math.pi * j / 49) * a for j in range(50)]
+        rows.append({"timestamp": i, "channel": "ch", "values": values})
+    df = pd.DataFrame(rows)
+    out = calculate_p2p(df)
+
+    assert out["p2p"].max() == pytest.approx(4.0, rel=1e-6)
+    assert out["p2p"].min() == pytest.approx(0, abs=1e-8)
+
+
+def test_calculate_rms_sine():
+    amp = 2.0
+    rows = []
+    steps = 10
+    for i in range(steps):
+        a = amp * i / (steps - 1)
+        values = [math.sin(2 * math.pi * j / 49) * a for j in range(50)]
+        rows.append({"timestamp": i, "channel": "ch", "values": values})
+    df = pd.DataFrame(rows)
+    out = calculate_rms(df)
+
+    assert out["rms"].max() == pytest.approx(1.4142, rel=1e-2)
+    assert out["rms"].min() == pytest.approx(0, abs=1e-8)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -228,7 +228,7 @@ class MainWindow(QMainWindow):
                 channels,
             )
         else:
-            self.trend_tab.update_view()
+            self.trend_tab.update_view(end_timestamp=timestamp)
 
     def _update_surgery_meta_label(self):
         if self.surgery_meta_df is None or self.surgery_meta_df.empty:


### PR DESCRIPTION
## Summary
- allow selecting trend method (L1, P2P, RMS)
- compute and plot chosen metric
- display trend data cumulatively up to the current timestamp
- update unit tests for new metric functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687fcee2d974832e91ecdc5762edd5cc