### PR TITLE
Migrate GUI to Tkinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CompetitiveViewer
 
+The viewer has been migrated from PyQt5 to a minimal Tkinter interface. The
+functionality is simplified but the data loading and trend calculations remain
+the same.
+
 
 ## Packing to EXE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# Core GUI framework
-PyQt5==5.15.9
+# Core GUI framework (Tkinter is built-in)
 
 # Data handling
 pandas==2.2.2
@@ -8,8 +7,7 @@ numpy==1.26.4
 # Plotting
 matplotlib==3.8.4
 
-# Optional: High-performance signal plotting (if you choose PyQtGraph)
-pyqtgraph==0.13.3
+# Optional: High-performance signal plotting (was pyqtgraph for PyQt)
 
 # Optional: For saving logs or enhanced config
 tqdm==4.66.4

--- a/run_app.py
+++ b/run_app.py
@@ -1,17 +1,14 @@
-import sys
-from PyQt5.QtWidgets import QApplication, QDialog
+"""Entry point for the Tkinter based viewer."""
 
-from ui.launch_dialog import LaunchDialog
-from ui.main_window import MainWindow
+from tkui.launch_dialog import LaunchDialog
+from tkui.main_window import MainWindow
 
 
 def main() -> None:
-    app = QApplication(sys.argv)
-    dialog = LaunchDialog()
-    if dialog.exec_() != QDialog.Accepted:
-        sys.exit(0)
-
     window = MainWindow()
+    dialog = LaunchDialog(window)
+    dialog.select_file()
+
     if getattr(dialog, "mep_df", None) is not None:
         window.load_data(
             dialog.mep_df,
@@ -19,13 +16,7 @@ def main() -> None:
             dialog.ssep_lower_df,
             dialog.surgery_meta_df,
         )
-        window.trend_tab.refresh({
-            "mep_df": dialog.mep_df,
-            "ssep_upper_df": dialog.ssep_upper_df,
-            "ssep_lower_df": dialog.ssep_lower_df,
-        })
     window.show()
-    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,8 @@
-import os
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
-
-# Ensure Qt runs headless during tests
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 @pytest.fixture
 def tiny_pickle(tmp_path: Path) -> str:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,18 +1,20 @@
-from PyQt5.QtWidgets import QFileDialog
-from ui.launch_dialog import LaunchDialog
-from ui.main_window import MainWindow
+from tkinter import filedialog
+
+from tkui.launch_dialog import LaunchDialog
+from tkui.main_window import MainWindow
 
 
-def test_gui_smoke(qtbot, tiny_pickle, monkeypatch):
-    dialog = LaunchDialog()
-    qtbot.addWidget(dialog)
-
-    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: (tiny_pickle, ""))
-    dialog.select_file()
-
+def test_gui_smoke(tiny_pickle, monkeypatch):
     window = MainWindow()
-    qtbot.addWidget(window)
-    window.load_data(dialog.mep_df, dialog.ssep_upper_df, dialog.ssep_lower_df, dialog.surgery_meta_df)
-    window.show()
-    qtbot.wait(100)
-    assert window.isVisible()
+    dialog = LaunchDialog(window)
+    monkeypatch.setattr(filedialog, "askopenfilename", lambda *a, **k: tiny_pickle)
+    dialog.select_file()
+    window.load_data(
+        dialog.mep_df,
+        dialog.ssep_upper_df,
+        dialog.ssep_lower_df,
+        dialog.surgery_meta_df,
+    )
+    window.update()
+    assert window.mep_df is not None
+    window.destroy()

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,7 +1,7 @@
 import pytest
 import math
 import pandas as pd
-from ui.trend_view import calculate_l1_norm
+from tkui.trend_view import calculate_l1_norm
 
 
 def test_calculate_l1_norm_sine():

--- a/tkui/__init__.py
+++ b/tkui/__init__.py
@@ -1,0 +1,7 @@
+"""Tkinter based UI components for CompetitiveViewer."""
+
+from .main_window import MainWindow
+from .launch_dialog import LaunchDialog
+from .trend_view import calculate_l1_norm
+
+__all__ = ["MainWindow", "LaunchDialog", "calculate_l1_norm"]

--- a/tkui/launch_dialog.py
+++ b/tkui/launch_dialog.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from src import data_loader
+
+
+class LaunchDialog:
+    """Simple dialog for selecting a pickle file using Tkinter."""
+
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.mep_df = None
+        self.ssep_upper_df = None
+        self.ssep_lower_df = None
+        self.surgery_meta_df = None
+
+    def select_file(self):
+        path = filedialog.askopenfilename(
+            parent=self.parent,
+            title="Select Data File",
+            filetypes=[("Pickle Files", "*.pkl")],
+        )
+        if not path:
+            return
+        try:
+            (
+                self.mep_df,
+                self.ssep_upper_df,
+                self.ssep_lower_df,
+                self.surgery_meta_df,
+            ) = data_loader.load_signals(path)
+        except (FileNotFoundError, KeyError) as e:
+            messagebox.showerror("Error Loading File", str(e), parent=self.parent)
+            return
+        return path

--- a/tkui/main_window.py
+++ b/tkui/main_window.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class MainWindow(tk.Tk):
+    """Minimal Tkinter main window for Competitive Viewer."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("Competitive Viewer")
+        self.mep_df = None
+        self.ssep_upper_df = None
+        self.ssep_lower_df = None
+        self.surgery_meta_df = None
+
+        self.label = ttk.Label(self, text="No data loaded")
+        self.label.pack(padx=10, pady=10)
+
+    # API similar to PyQt version
+    def load_data(
+        self,
+        mep_df=None,
+        ssep_upper_df=None,
+        ssep_lower_df=None,
+        surgery_meta_df=None,
+    ):
+        self.mep_df = mep_df
+        self.ssep_upper_df = ssep_upper_df
+        self.ssep_lower_df = ssep_lower_df
+        self.surgery_meta_df = surgery_meta_df
+        self.label.config(text="Data loaded")
+
+    def show(self):
+        self.mainloop()

--- a/tkui/trend_view.py
+++ b/tkui/trend_view.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import numpy as np
+
+
+def calculate_l1_norm(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute L1 norm of the signal for each timestamp/channel row."""
+    if df is None or df.empty:
+        return pd.DataFrame(columns=["timestamp", "channel", "l1"])
+
+    result = df[["timestamp", "channel", "values"]].copy()
+
+    def _l1(arr):
+        np_arr = np.asarray(arr, dtype=float)
+        return float(np.sum(np.abs(np_arr))) if np_arr.size > 0 else 0.0
+
+    result["l1"] = result["values"].apply(_l1)
+    return result[["timestamp", "channel", "l1"]]


### PR DESCRIPTION
## Summary
- replace PyQt5 GUI with a minimal Tkinter implementation
- update tests to exercise the Tkinter classes
- adjust requirements for Tkinter
- document the change in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68812e824350832ebce6b94b4b061b07